### PR TITLE
Added postgresql-ssl-cert to check and update SSL certificates on PostgreSQL nodes

### DIFF
--- a/postgresql-ssl-cert/includes/postgresql-ssl.yml
+++ b/postgresql-ssl-cert/includes/postgresql-ssl.yml
@@ -6,11 +6,11 @@
 
 - name: Get information about current SSL certificate
   command: /bin/openssl x509 -enddate -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.crt
-  register: ssl_check_result
+  register: ssl_current_cert_info
   changed_when: false
 
 - name: Show information about current SSL certificate expiration
-  debug: msg="{{ ssl_check_result.stdout }}"
+  debug: msg="{{ ssl_current_cert_info.stdout }}"
 
 - name: "Write latest SSL cert to temp file"
   copy:
@@ -22,16 +22,16 @@
 
 - name: Get information about latest SSL certificate
   command: /bin/openssl x509 -enddate -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.crt
-  register: ssl_check_result
+  register: ssl_latest_cert_info
   changed_when: false
 
 - name: Show information about latest SSL certificate expiration
-  debug: msg="{{ ssl_check_result.stdout }}"
+  debug: msg="{{ ssl_latest_cert_info.stdout }}"
 
 - name: "Make sure the latest SSL certificate is not about to expire"
   command: /bin/openssl x509 -checkend 2592000 -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.tmp
-  register: ssl_check_result
-  failed_when: "ssl_check_result.rc != 0"
+  register: ssl_latest_cert_check
+  failed_when: "ssl_latest_cert_check.rc != 0"
   changed_when: false
 
 - name: "Write latest SSL cert to file"

--- a/postgresql-ssl-cert/includes/postgresql-ssl.yml
+++ b/postgresql-ssl-cert/includes/postgresql-ssl.yml
@@ -1,0 +1,55 @@
+---
+- name: Get information about current SSL certificate
+  command: /bin/openssl x509 -enddate -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.crt
+  register: ssl_check_result
+  changed_when: false
+
+- name: Show information about current SSL certificate expiration
+  debug: msg="{{ ssl_check_result.stdout }}"
+
+- name: "Write latest SSL cert to temp file"
+  copy:
+    dest: "/var/lib/pgsql/{{ postgresql_version }}/data/server.tmp"
+    content: "{{ postgresql_ssl_crt }}"
+    mode: 0400
+    owner: postgres
+    group: postgres
+
+- name: Get information about latest SSL certificate
+  command: /bin/openssl x509 -enddate -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.crt
+  register: ssl_check_result
+  changed_when: false
+
+- name: Show information about latest SSL certificate expiration
+  debug: msg="{{ ssl_check_result.stdout }}"
+
+- name: "Make sure the latest SSL certificate is not about to expire"
+  command: /bin/openssl x509 -checkend 2592000 -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.tmp
+  register: ssl_check_result
+  failed_when: "ssl_check_result.rc != 0"
+  changed_when: false
+
+- name: "Write latest SSL cert to file"
+  copy:
+    dest: "/var/lib/pgsql/{{ postgresql_version }}/data/server.crt"
+    content: "{{ postgresql_ssl_crt }}"
+    mode: 0400
+    owner: postgres
+    group: postgres
+  register: ssl_update_crt
+
+- name: "Write latest SSL key to file"
+  copy:
+    dest: "/var/lib/pgsql/{{ postgresql_version }}/data/server.key"
+    content: "{{ postgresql_ssl_key }}"
+    mode: 0400
+    owner: postgres
+    group: postgres
+  register: ssl_update_key
+
+- name: "Restart PostgreSQL service if required"
+  systemd:
+    name: postgresql-{{ postgresql_version }}
+    state: restarted
+    daemon-reload: yes
+  when: ssl_update_crt.changed or ssl_update_key.changed

--- a/postgresql-ssl-cert/includes/postgresql-ssl.yml
+++ b/postgresql-ssl-cert/includes/postgresql-ssl.yml
@@ -20,14 +20,6 @@
     owner: postgres
     group: postgres
 
-- name: Get information about latest SSL certificate
-  command: /bin/openssl x509 -enddate -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.crt
-  register: ssl_latest_cert_info
-  changed_when: false
-
-- name: Show information about latest SSL certificate expiration
-  debug: msg="{{ ssl_latest_cert_info.stdout }}"
-
 - name: "Make sure the latest SSL certificate is not about to expire"
   command: /bin/openssl x509 -checkend 2592000 -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.tmp
   register: ssl_latest_cert_check
@@ -51,6 +43,14 @@
     owner: postgres
     group: postgres
   register: ssl_update_key
+
+- name: Get information about latest SSL certificate
+  command: /bin/openssl x509 -enddate -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.crt
+  register: ssl_latest_cert_info
+  changed_when: false
+
+- name: Show information about latest SSL certificate expiration
+  debug: msg="{{ ssl_latest_cert_info.stdout }}"
 
 - name: "Restart PostgreSQL service if required"
   systemd:

--- a/postgresql-ssl-cert/includes/postgresql-ssl.yml
+++ b/postgresql-ssl-cert/includes/postgresql-ssl.yml
@@ -1,4 +1,9 @@
 ---
+- name: Make sure the PostgreSQL service is active
+  command: /bin/systemctl is-active postgresql-{{ postgresql_version }}
+  register: service_status
+  failed_when: "service_status.rc != 0"
+
 - name: Get information about current SSL certificate
   command: /bin/openssl x509 -enddate -noout -in /var/lib/pgsql/{{ postgresql_version }}/data/server.crt
   register: ssl_check_result

--- a/postgresql-ssl-cert/includes/postgresql-ssl.yml
+++ b/postgresql-ssl-cert/includes/postgresql-ssl.yml
@@ -2,6 +2,7 @@
 - name: Make sure the PostgreSQL service is active
   command: /bin/systemctl is-active postgresql-{{ postgresql_version }}
   register: service_status
+  changed_when: false
   failed_when: "service_status.rc != 0"
 
 - name: Get information about current SSL certificate

--- a/postgresql-ssl-cert/main.yml
+++ b/postgresql-ssl-cert/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Check and update PostgreSQL SSL certificate
+  hosts: "{{ host_to_apply_to }}"
+  serial: 1
+  become: yes
+
+  vars:
+    postgresql_version: "9.6"
+    postgresql_ssl_key: "{{ lookup('hashi_vault', 'secret=secret/devops/dev/ssl/ssl_key_STAR_reform_hmcts_net:value') | replace('\\n', '\n') }}"
+    postgresql_ssl_crt: "{{ lookup('hashi_vault', 'secret=secret/devops/dev/ssl/ssl_crt_STAR_reform_hmcts_net:value') | replace('\\n', '\n') }}"
+
+  tasks:
+    - name: Check and update PostgreSQL SSL certificate
+      include_tasks: includes/postgresql-ssl.yml


### PR DESCRIPTION
This simple oneshot allows to check the state of the current SSL certificate on PostgreSQL and to automatically update it to the latest version